### PR TITLE
Return ErrorType for type on invalid extension

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1994,10 +1994,8 @@ Type NominalTypeDecl::getDeclaredTypeInContext() const {
     return DeclaredTyInContext;
 
   auto *decl = const_cast<NominalTypeDecl *>(this);
-  auto Ty = computeNominalType(decl, DeclTypeKind::DeclaredTypeInContext);
-  if (!Ty)
-    Ty = ErrorType::get(getASTContext());
-  decl->DeclaredTyInContext = Ty;
+  decl->DeclaredTyInContext = computeNominalType(decl,
+                                                 DeclTypeKind::DeclaredTypeInContext);
   return DeclaredTyInContext;
 }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -127,8 +127,10 @@ enum class DeclTypeKind : unsigned {
 };
 
 static Type computeExtensionType(const ExtensionDecl *ED, DeclTypeKind kind) {
-  auto type = ED->getExtendedType();
+  if (ED->isInvalid())
+    return ErrorType::get(ED->getASTContext());
 
+  auto type = ED->getExtendedType();
   if (!type)
     return Type();
 

--- a/validation-test/compiler_crashers_fixed/28324-swift-diagnosticengine-emitdiagnostic.swift
+++ b/validation-test/compiler_crashers_fixed/28324-swift-diagnosticengine-emitdiagnostic.swift
@@ -5,5 +5,6 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-class d{init(){{extension{{}protocol a{struct B{let a
+// RUN: not %target-swift-frontend %s -parse
+// REQUIRES: asserts
+protocol a{extension{@objc protocol A:a

--- a/validation-test/compiler_crashers_fixed/28326-swift-typebase-getmembersubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/28326-swift-typebase-getmembersubstitutions.swift
@@ -5,6 +5,5 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -parse
-// REQUIRES: asserts
-protocol a{extension{@objc protocol A:a
+// RUN: not %target-swift-frontend %s -parse
+class d{init(){{extension{{}protocol a{struct B{let a


### PR DESCRIPTION
This is a better fix for crash 28328 than commit a870bdbd23ed0f461e9a6b5fe0d9f6d37e134cb3. Also fixes additional
crashers.
